### PR TITLE
Add TomTom comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Required arguments:
 
 
 Optional arguments:
-- `--google-max-rpm [int]`: Set max number of parallel requests sent to Google API per minute. Default is 60. 
+- `--google-max-rpm [int]`: Set max number of parallel requests sent to Google API per minute. Default is 60.
+  It is enforced on per-second basis, to avoid bursts.
+- `--tomtom-max-rpm [int]`: Set max number of parallel requests sent to TomTom API per minute. Default is 60.
   It is enforced on per-second basis, to avoid bursts.
 - `--traveltime-max-rpm [int]`: Set max number of parallel requests sent to TravelTime API per minute. Default is 60.
   It is enforced on per-second basis, to avoid bursts.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ For Google Maps API:
 export GOOGLE_API_KEY=[Your Google Maps API Key]
 ```
 
+For TomTom Maps API:
+
+```bash
+export TOMTOM_API_KEY=[Your TomTom API Key]
+```
+
 For TravelTime API:
 ```bash
 export TRAVELTIME_APP_ID=[Your TravelTime App ID]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For Google Maps API:
 export GOOGLE_API_KEY=[Your Google Maps API Key]
 ```
 
-For TomTom Maps API:
+For TomTom API:
 
 ```bash
 export TOMTOM_API_KEY=[Your TomTom API Key]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Source code is available on [GitHub](https://github.com/traveltime-dev/traveltim
 
 ## Features
 
-- Get travel times from TravelTime API, Google Maps API and TomTom in parallel, for provided origin/destination pairs and a set 
+- Get travel times from TravelTime API, Google Maps API and TomTom API in parallel, for provided origin/destination pairs and a set 
     of departure times.
 - Departure times are calculated based on user provided start time, end time and interval.  
 - Analyze the differences between the results and print out the average error percentage.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # TravelTime/Google comparison tool
 
-This tool compares the travel times obtained from [TravelTime Routes API](https://docs.traveltime.com/api/reference/routes) 
-and [Google Maps Directions API](https://developers.google.com/maps/documentation/directions/get-directions).
+This tool compares the travel times obtained from [TravelTime Routes API](https://docs.traveltime.com/api/reference/routes),
+[Google Maps Directions API](https://developers.google.com/maps/documentation/directions/get-directions),
+and [TomTom Routing API](https://developer.tomtom.com/routing-api/documentation/tomtom-maps/routing-service).
 Source code is available on [GitHub](https://github.com/traveltime-dev/traveltime-google-comparison).
 
 ## Features
 
-- Get travel times from TravelTime API and Google Maps API in parallel, for provided origin/destination pairs and a set 
+- Get travel times from TravelTime API, Google Maps API and TomTom in parallel, for provided origin/destination pairs and a set 
     of departure times.
 - Departure times are calculated based on user provided start time, end time and interval.  
 - Analyze the differences between the results and print out the average error percentage.
@@ -114,13 +115,13 @@ The output file will contain the `origin` and `destination` columns from input f
 
 ### Sample output
 ```csv
-origin,destination,departure_time,google_travel_time,tt_travel_time,error_percentage
-"52.1849867903527, 0.1809343829904072","52.202817030086266, 0.10935651695330152",2024-05-28 06:00:00+0100,718.0,1050.0,46
-"52.1849867903527, 0.1809343829904072","52.202817030086266, 0.10935651695330152",2024-05-28 09:00:00+0100,1427.0,1262.0,11
-"52.1849867903527, 0.1809343829904072","52.202817030086266, 0.10935651695330152",2024-05-28 12:00:00+0100,1064.0,1165.0,9
-"52.1849867903527, 0.1809343829904072","52.202817030086266, 0.10935651695330152",2024-05-28 15:00:00+0100,1240.0,1287.0,3
-"52.1849867903527, 0.1809343829904072","52.202817030086266, 0.10935651695330152",2024-05-28 18:00:00+0100,1312.0,1223.0,6
-"52.18553917820687, 0.12702050752253252","52.22715259892737, 0.14811674226050345",2024-05-28 06:00:00+0100,749.0,903.0,20
+origin,destination,departure_time,google_travel_time,tomtom_travel_time,tt_travel_time,error_percentage_google,error_percentage_tomtom
+"50.077012199999984, -5.2234787","50.184134100000726, -5.593753699999999",2024-09-20 07:00:00+0100,2276.0,2388.0,2071.0,9,13
+"50.077012199999984, -5.2234787","50.184134100000726, -5.593753699999999",2024-09-20 10:00:00+0100,2702.0,2578.0,2015.0,25,21
+"50.077012199999984, -5.2234787","50.184134100000726, -5.593753699999999",2024-09-20 13:00:00+0100,2622.0,2585.0,2015.0,23,22
+"50.077012199999984, -5.2234787","50.184134100000726, -5.593753699999999",2024-09-20 16:00:00+0100,2607.0,2596.0,2130.0,18,17
+"50.077012199999984, -5.2234787","50.184134100000726, -5.593753699999999",2024-09-20 19:00:00+0100,2398.0,2431.0,1960.0,18,19
+"50.09814150000003, -5.2586104000000065","50.2165765000003, -5.4758540000000036",2024-09-20 07:00:00+0100,2175.0,2357.0,1861.0,14,21
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiolimiter",
     "pandas",
     "pytz",
-    "traveltimepy==0.1.1.dev2"
+    "traveltimepy==0.1.1.dev3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiolimiter",
     "pandas",
     "pytz",
-    "traveltimepy==0.1.1.dev1"
+    "traveltimepy==0.1.1.dev2"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,6 @@ test = [
     "flake8-pyproject",
     "mypy",
     "black",
-    "pandas-stubs",
-    "types-pytz",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiolimiter",
     "pandas",
     "pytz",
-    "traveltimepy==0.1.1.dev5"
+    "traveltimepy"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ test = [
     "flake8-pyproject",
     "mypy",
     "black",
+    "pandas-stubs",
+    "types-pytz",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiolimiter",
     "pandas",
     "pytz",
-    "traveltimepy==0.1.1.dev3"
+    "traveltimepy==0.1.1.dev5"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "aiolimiter",
     "pandas",
     "pytz",
-    "traveltimepy"
+    "traveltimepy==0.1.1.dev1"
 ]
 
 [project.urls]

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -31,7 +31,7 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
         f"Mean relative error compared to Google API: {results_with_differences[RELATIVE_ERROR_GOOGLE].mean():.2f}%"
     )
     quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, ABSOLUTE_ERROR_GOOGLE
+        results_with_differences, quantile, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
     )
     logging.info(
         f"{int(quantile * 100)}% of TravelTime results differ from Google API "
@@ -42,7 +42,7 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
         f"Mean relative error compared to TomTom API: {results_with_differences[RELATIVE_ERROR_TOMTOM].mean():.2f}%"
     )
     quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, ABSOLUTE_ERROR_TOMTOM
+        results_with_differences, quantile, ABSOLUTE_ERROR_TOMTOM, RELATIVE_ERROR_TOMTOM
     )
     logging.info(
         f"{int(quantile * 100)}% of TravelTime results differ from TomTom API "
@@ -94,11 +94,12 @@ def calculate_quantiles(
     results_with_differences: DataFrame,
     quantile: float,
     absolute_error_str: str,
+    relative_error_str: str,
 ) -> QuantileErrorResult:
     quantile_absolute_error = results_with_differences[absolute_error_str].quantile(
         quantile, "higher"
     )
-    quantile_relative_error = results_with_differences[absolute_error_str].quantile(
+    quantile_relative_error = results_with_differences[relative_error_str].quantile(
         quantile, "higher"
     )
     return QuantileErrorResult(

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -2,7 +2,6 @@ import logging
 from dataclasses import dataclass
 
 from pandas import DataFrame
-import pandas
 
 from traveltime_google_comparison.collect import (
     TOMTOM_API,
@@ -28,8 +27,6 @@ class QuantileErrorResult:
 
 def run_analysis(results: DataFrame, output_file: str, quantile: float):
     results_with_differences = calculate_differences(results)
-
-    print(results_with_differences)
 
     logging.info(
         f"Mean relative error compared to Google API: {results_with_differences[relative_error(GOOGLE_API)].mean():.2f}%"

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -13,8 +13,8 @@ from traveltime_google_comparison.collect import (
 
 ABSOLUTE_ERROR_GOOGLE = "absolute_error_to_google"
 RELATIVE_ERROR_GOOGLE = "error_percentage_to_google"
-ABSOLUTE_ERROR_TOMTOM = "absolute_error_to_google"
-RELATIVE_ERROR_TOMTOM = "error_percentage_to_google"
+ABSOLUTE_ERROR_TOMTOM = "absolute_error_to_tomtom"
+RELATIVE_ERROR_TOMTOM = "error_percentage_to_tomtom"
 
 
 @dataclass
@@ -58,10 +58,10 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
     )
 
     results_with_differences[
-        RELATIVE_ERROR_GOOGLE(GOOGLE_API)
+        RELATIVE_ERROR_GOOGLE
     ] = results_with_differences[RELATIVE_ERROR_GOOGLE].astype(int)
     results_with_differences[
-        RELATIVE_ERROR_GOOGLE(TOMTOM_API)
+        RELATIVE_ERROR_TOMTOM
     ] = results_with_differences[RELATIVE_ERROR_TOMTOM].astype(int)
 
     results_with_differences.to_csv(output_file, index=False)

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -57,12 +57,12 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
         columns=[ABSOLUTE_ERROR_TOMTOM]
     )
 
-    results_with_differences[
+    results_with_differences[RELATIVE_ERROR_GOOGLE] = results_with_differences[
         RELATIVE_ERROR_GOOGLE
-    ] = results_with_differences[RELATIVE_ERROR_GOOGLE].astype(int)
-    results_with_differences[
+    ].astype(int)
+    results_with_differences[RELATIVE_ERROR_TOMTOM] = results_with_differences[
         RELATIVE_ERROR_TOMTOM
-    ] = results_with_differences[RELATIVE_ERROR_TOMTOM].astype(int)
+    ].astype(int)
 
     results_with_differences.to_csv(output_file, index=False)
 

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -12,8 +12,12 @@ from traveltime_google_comparison.collect import (
 )
 
 
-def absolute_error(compare_to: str) -> str: return f"absolute_error_{compare_to}"
-def relative_error(compare_to: str) -> str: return f"error_percentage_{compare_to}"
+def absolute_error(compare_to: str) -> str:
+    return f"absolute_error_{compare_to}"
+
+
+def relative_error(compare_to: str) -> str:
+    return f"error_percentage_{compare_to}"
 
 
 @dataclass
@@ -57,10 +61,10 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
     )
 
     results_with_differences[relative_error(GOOGLE_API)] = results_with_differences[
-       relative_error(GOOGLE_API) 
+        relative_error(GOOGLE_API)
     ].astype(int)
     results_with_differences[relative_error(TOMTOM_API)] = results_with_differences[
-       relative_error(TOMTOM_API) 
+        relative_error(TOMTOM_API)
     ].astype(int)
 
     results_with_differences.to_csv(output_file, index=False)
@@ -93,12 +97,12 @@ def calculate_quantiles(
     quantile: float,
     compare_to: str,
 ) -> QuantileErrorResult:
-    quantile_absolute_error = results_with_differences[absolute_error(compare_to)].quantile(
-        quantile, "higher"
-    )
-    quantile_relative_error = results_with_differences[relative_error(compare_to)].quantile(
-        quantile, "higher"
-    )
+    quantile_absolute_error = results_with_differences[
+        absolute_error(compare_to)
+    ].quantile(quantile, "higher")
+    quantile_relative_error = results_with_differences[
+        relative_error(compare_to)
+    ].quantile(quantile, "higher")
     return QuantileErrorResult(
         int(quantile_absolute_error), int(quantile_relative_error)
     )

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -4,7 +4,11 @@ from typing import List
 
 from pandas import DataFrame
 
-from traveltime_google_comparison.collect import Fields, TRAVELTIME_API
+from traveltime_google_comparison.collect import (
+    Fields,
+    TRAVELTIME_API,
+    get_capitalized_provider_name,
+)
 
 
 def absolute_error(api_provider: str) -> str:
@@ -25,15 +29,16 @@ def log_results(
     results_with_differences: DataFrame, quantile: float, api_providers: List[str]
 ):
     for provider in api_providers:
+        capitalized_provider = get_capitalized_provider_name(provider)
         logging.info(
-            f"Mean relative error compared to {provider} "
+            f"Mean relative error compared to {capitalized_provider} "
             f"API: {results_with_differences[relative_error(provider)].mean():.2f}%"
         )
         quantile_errors = calculate_quantiles(
             results_with_differences, quantile, provider
         )
         logging.info(
-            f"{int(quantile * 100)}% of TravelTime results differ from {provider} API "
+            f"{int(quantile * 100)}% of TravelTime results differ from {capitalized_provider} API "
             f"by less than {int(quantile_errors.relative_error)}%"
         )
 

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -21,19 +21,19 @@ class QuantileErrorResult:
     relative_error: int
 
 
-def log_resuluts(
+def log_results(
     results_with_differences: DataFrame, quantile: float, api_providers: List[str]
 ):
     for provider in api_providers:
         logging.info(
-            f"Mean relative error compared to {provider.upper()} "
+            f"Mean relative error compared to {provider} "
             f"API: {results_with_differences[relative_error(provider)].mean():.2f}%"
         )
         quantile_errors = calculate_quantiles(
             results_with_differences, quantile, provider
         )
         logging.info(
-            f"{int(quantile * 100)}% of TravelTime results differ from {provider.upper()} API "
+            f"{int(quantile * 100)}% of TravelTime results differ from {provider} API "
             f"by less than {int(quantile_errors.relative_error)}%"
         )
 
@@ -57,7 +57,7 @@ def run_analysis(
     results: DataFrame, output_file: str, quantile: float, api_providers: List[str]
 ):
     results_with_differences = calculate_differences(results, api_providers)
-    log_resuluts(results_with_differences, quantile, api_providers)
+    log_results(results_with_differences, quantile, api_providers)
 
     logging.info(f"Detailed results can be found in {output_file} file")
 

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import List
 
 from pandas import DataFrame
-import pandas
 
 from traveltime_google_comparison.collect import (
     TOMTOM_API,

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -2,11 +2,22 @@ import logging
 from dataclasses import dataclass
 
 from pandas import DataFrame
+import pandas
 
-from traveltime_google_comparison.collect import Fields, GOOGLE_API, TRAVELTIME_API
+from traveltime_google_comparison.collect import (
+    TOMTOM_API,
+    Fields,
+    GOOGLE_API,
+    TRAVELTIME_API,
+)
 
-ABSOLUTE_ERROR = "absolute_error"
-RELATIVE_ERROR = "error_percentage"
+
+def absolute_error(compareTo: str) -> str:
+    return f"absolute_error_to_{compareTo}"
+
+
+def relative_error(compareTo: str) -> str:
+    return f"error_percentage_to_{compareTo}"
 
 
 @dataclass
@@ -17,20 +28,45 @@ class QuantileErrorResult:
 
 def run_analysis(results: DataFrame, output_file: str, quantile: float):
     results_with_differences = calculate_differences(results)
+
+    print(results_with_differences)
+
     logging.info(
-        f"Mean relative error: {results_with_differences[RELATIVE_ERROR].mean():.2f}%"
+        f"Mean relative error compared to Google API: {results_with_differences[relative_error(GOOGLE_API)].mean():.2f}%"
     )
-    quantile_errors = calculate_quantiles(results_with_differences, quantile)
+    quantile_errors = calculate_quantiles(
+        results_with_differences, quantile, GOOGLE_API
+    )
     logging.info(
         f"{int(quantile * 100)}% of TravelTime results differ from Google API "
         f"by less than {int(quantile_errors.relative_error)}%"
     )
 
+    logging.info(
+        f"Mean relative error compared to TomTom API: {results_with_differences[relative_error(TOMTOM_API)].mean():.2f}%"
+    )
+    quantile_errors = calculate_quantiles(
+        results_with_differences, quantile, TOMTOM_API
+    )
+    logging.info(
+        f"{int(quantile * 100)}% of TravelTime results differ from TomTom API "
+        f"by less than {int(quantile_errors.relative_error)}%"
+    )
+
     logging.info(f"Detailed results can be found in {output_file} file")
 
-    results_with_differences = results_with_differences.drop(columns=[ABSOLUTE_ERROR])
-    results_with_differences[RELATIVE_ERROR] = results_with_differences[
-        RELATIVE_ERROR
+    results_with_differences = results_with_differences.drop(
+        columns=[absolute_error(GOOGLE_API)]
+    )
+    results_with_differences = results_with_differences.drop(
+        columns=[absolute_error(TOMTOM_API)]
+    )
+
+    results_with_differences[relative_error(GOOGLE_API)] = results_with_differences[
+        relative_error(GOOGLE_API)
+    ].astype(int)
+    results_with_differences[relative_error(TOMTOM_API)] = results_with_differences[
+        relative_error(TOMTOM_API)
     ].astype(int)
 
     results_with_differences.to_csv(output_file, index=False)
@@ -39,30 +75,47 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
 def calculate_differences(results: DataFrame) -> DataFrame:
     results_with_differences = results.assign(
         **{
-            ABSOLUTE_ERROR: abs(
+            absolute_error(GOOGLE_API): abs(
                 results[Fields.TRAVEL_TIME[GOOGLE_API]]
                 - results[Fields.TRAVEL_TIME[TRAVELTIME_API]]
             )
         }
     )
 
-    results_with_differences[RELATIVE_ERROR] = (
-        results_with_differences[ABSOLUTE_ERROR]
+    results_with_differences[relative_error(GOOGLE_API)] = (
+        results_with_differences[absolute_error(GOOGLE_API)]
         / results_with_differences[Fields.TRAVEL_TIME[GOOGLE_API]]
+        * 100
+    )
+
+    results_with_differences = results_with_differences.assign(
+        **{
+            absolute_error(TOMTOM_API): abs(
+                results[Fields.TRAVEL_TIME[TOMTOM_API]]
+                - results[Fields.TRAVEL_TIME[TRAVELTIME_API]]
+            )
+        }
+    )
+
+    results_with_differences[relative_error(TOMTOM_API)] = (
+        results_with_differences[absolute_error(TOMTOM_API)]
+        / results_with_differences[Fields.TRAVEL_TIME[TOMTOM_API]]
         * 100
     )
     return results_with_differences
 
 
 def calculate_quantiles(
-    results_with_differences: DataFrame, quantile: float
+    results_with_differences: DataFrame,
+    quantile: float,
+    compareTo: str,
 ) -> QuantileErrorResult:
-    quantile_absolute_error = results_with_differences[ABSOLUTE_ERROR].quantile(
-        quantile, "higher"
-    )
-    quantile_relative_error = results_with_differences[RELATIVE_ERROR].quantile(
-        quantile, "higher"
-    )
+    quantile_absolute_error = results_with_differences[
+        absolute_error(compareTo)
+    ].quantile(quantile, "higher")
+    quantile_relative_error = results_with_differences[
+        relative_error(compareTo)
+    ].quantile(quantile, "higher")
     return QuantileErrorResult(
         int(quantile_absolute_error), int(quantile_relative_error)
     )

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -26,7 +26,8 @@ def log_resuluts(
 ):
     for provider in api_providers:
         logging.info(
-            f"Mean relative error compared to {provider.upper()} API: {results_with_differences[relative_error(provider)].mean():.2f}%"
+            f"Mean relative error compared to {provider.upper()} "
+            f"API: {results_with_differences[relative_error(provider)].mean():.2f}%"
         )
         quantile_errors = calculate_quantiles(
             results_with_differences, quantile, provider

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -4,20 +4,15 @@ from typing import List
 
 from pandas import DataFrame
 
-from traveltime_google_comparison.collect import (
-    TOMTOM_API,
-    Fields,
-    GOOGLE_API,
-    TRAVELTIME_API,
-)
+from traveltime_google_comparison.collect import Fields,TRAVELTIME_API
 
 
-def absolute_error(compare_to: str) -> str:
-    return f"absolute_error_{compare_to}"
+def absolute_error(api_provider: str) -> str:
+    return f"absolute_error_{api_provider}"
 
 
-def relative_error(compare_to: str) -> str:
-    return f"error_percentage_{compare_to}"
+def relative_error(api_provider: str) -> str:
+    return f"error_percentage_{api_provider}"
 
 
 @dataclass
@@ -26,68 +21,67 @@ class QuantileErrorResult:
     relative_error: int
 
 
-def run_analysis(results: DataFrame, output_file: str, quantile: float):
-    results_with_differences = calculate_differences(results, [GOOGLE_API, TOMTOM_API])
+def log_resuluts(
+    results_with_differences: DataFrame, quantile: float, api_providers: List[str]
+):
+    for provider in api_providers:
+        logging.info(
+            f"Mean relative error compared to {provider.upper()} API: {results_with_differences[relative_error(provider)].mean():.2f}%"
+        )
+        quantile_errors = calculate_quantiles(
+            results_with_differences, quantile, provider
+        )
+        logging.info(
+            f"{int(quantile * 100)}% of TravelTime results differ from {provider.upper()} API "
+            f"by less than {int(quantile_errors.relative_error)}%"
+        )
 
-    logging.info(
-        f"Mean relative error compared to Google API: {results_with_differences[relative_error(GOOGLE_API)].mean():.2f}%"
-    )
-    quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, GOOGLE_API
-    )
-    logging.info(
-        f"{int(quantile * 100)}% of TravelTime results differ from Google API "
-        f"by less than {int(quantile_errors.relative_error)}%"
-    )
 
-    logging.info(
-        f"Mean relative error compared to TomTom API: {results_with_differences[relative_error(TOMTOM_API)].mean():.2f}%"
-    )
-    quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, TOMTOM_API
-    )
-    logging.info(
-        f"{int(quantile * 100)}% of TravelTime results differ from TomTom API "
-        f"by less than {int(quantile_errors.relative_error)}%"
-    )
+def format_results_for_csv(
+    results_with_differences: DataFrame, api_providers: List[str]
+) -> DataFrame:
+    formatted_results = results_with_differences.copy()
+
+    for provider in api_providers:
+        formatted_results = formatted_results.drop(columns=[absolute_error(provider)])
+        relative_error_col = relative_error(provider)
+        formatted_results[relative_error_col] = formatted_results[
+            relative_error_col
+        ].astype(int)
+
+    return formatted_results
+
+
+def run_analysis(
+    results: DataFrame, output_file: str, quantile: float, api_providers: List[str]
+):
+    results_with_differences = calculate_differences(results, api_providers)
+    log_resuluts(results_with_differences, quantile, api_providers)
 
     logging.info(f"Detailed results can be found in {output_file} file")
 
-    results_with_differences = results_with_differences.drop(
-        columns=[absolute_error(GOOGLE_API)]
-    )
-    results_with_differences = results_with_differences.drop(
-        columns=[absolute_error(TOMTOM_API)]
-    )
+    formatted_results = format_results_for_csv(results_with_differences, api_providers)
 
-    results_with_differences[relative_error(GOOGLE_API)] = results_with_differences[
-        relative_error(GOOGLE_API)
-    ].astype(int)
-    results_with_differences[relative_error(TOMTOM_API)] = results_with_differences[
-        relative_error(TOMTOM_API)
-    ].astype(int)
-
-    results_with_differences.to_csv(output_file, index=False)
+    formatted_results.to_csv(output_file, index=False)
 
 
-def calculate_differences(results: DataFrame, providers: List[str]) -> DataFrame:
+def calculate_differences(results: DataFrame, api_providers: List[str]) -> DataFrame:
     results_with_differences = results.copy()
 
-    for provider in providers:
-        if provider != TRAVELTIME_API:
-            absolute_error_col = f"absolute_error_{provider}"
-            relative_error_col = f"error_percentage_{provider}"
+    for provider in api_providers:
+        absolute_error_col = f"absolute_error_{provider}"
+        relative_error_col = f"error_percentage_{provider}"
 
-            results_with_differences[absolute_error_col] = abs(
-                results[Fields.TRAVEL_TIME[provider]]
-                - results[Fields.TRAVEL_TIME[TRAVELTIME_API]]
-            )
+        results_with_differences[absolute_error_col] = abs(
+            results[Fields.TRAVEL_TIME[provider]]
+            - results[Fields.TRAVEL_TIME[TRAVELTIME_API]]
+        )
 
-            results_with_differences[relative_error_col] = (
-                results_with_differences[absolute_error_col]
-                / results_with_differences[Fields.TRAVEL_TIME[provider]]
-                * 100
-            )
+        results_with_differences[relative_error_col] = (
+            results_with_differences[absolute_error_col]
+            / results_with_differences[Fields.TRAVEL_TIME[provider]]
+            * 100
+        )
 
     return results_with_differences
 
@@ -95,13 +89,13 @@ def calculate_differences(results: DataFrame, providers: List[str]) -> DataFrame
 def calculate_quantiles(
     results_with_differences: DataFrame,
     quantile: float,
-    compare_to: str,
+    api_provider: str,
 ) -> QuantileErrorResult:
     quantile_absolute_error = results_with_differences[
-        absolute_error(compare_to)
+        absolute_error(api_provider)
     ].quantile(quantile, "higher")
     quantile_relative_error = results_with_differences[
-        relative_error(compare_to)
+        relative_error(api_provider)
     ].quantile(quantile, "higher")
     return QuantileErrorResult(
         int(quantile_absolute_error), int(quantile_relative_error)

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -12,10 +12,8 @@ from traveltime_google_comparison.collect import (
 )
 
 
-ABSOLUTE_ERROR_GOOGLE = "absolute_error_google"
-RELATIVE_ERROR_GOOGLE = "error_percentage_google"
-ABSOLUTE_ERROR_TOMTOM = "absolute_error_tomtom"
-RELATIVE_ERROR_TOMTOM = "error_percentage_tomtom"
+def absolute_error(compare_to: str) -> str: return f"absolute_error_{compare_to}"
+def relative_error(compare_to: str) -> str: return f"error_percentage_{compare_to}"
 
 
 @dataclass
@@ -28,10 +26,10 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
     results_with_differences = calculate_differences(results, [GOOGLE_API, TOMTOM_API])
 
     logging.info(
-        f"Mean relative error compared to Google API: {results_with_differences[RELATIVE_ERROR_GOOGLE].mean():.2f}%"
+        f"Mean relative error compared to Google API: {results_with_differences[relative_error(GOOGLE_API)].mean():.2f}%"
     )
     quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        results_with_differences, quantile, GOOGLE_API
     )
     logging.info(
         f"{int(quantile * 100)}% of TravelTime results differ from Google API "
@@ -39,10 +37,10 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
     )
 
     logging.info(
-        f"Mean relative error compared to TomTom API: {results_with_differences[RELATIVE_ERROR_TOMTOM].mean():.2f}%"
+        f"Mean relative error compared to TomTom API: {results_with_differences[relative_error(TOMTOM_API)].mean():.2f}%"
     )
     quantile_errors = calculate_quantiles(
-        results_with_differences, quantile, ABSOLUTE_ERROR_TOMTOM, RELATIVE_ERROR_TOMTOM
+        results_with_differences, quantile, TOMTOM_API
     )
     logging.info(
         f"{int(quantile * 100)}% of TravelTime results differ from TomTom API "
@@ -52,17 +50,17 @@ def run_analysis(results: DataFrame, output_file: str, quantile: float):
     logging.info(f"Detailed results can be found in {output_file} file")
 
     results_with_differences = results_with_differences.drop(
-        columns=[ABSOLUTE_ERROR_GOOGLE]
+        columns=[absolute_error(GOOGLE_API)]
     )
     results_with_differences = results_with_differences.drop(
-        columns=[ABSOLUTE_ERROR_TOMTOM]
+        columns=[absolute_error(TOMTOM_API)]
     )
 
-    results_with_differences[RELATIVE_ERROR_GOOGLE] = results_with_differences[
-        RELATIVE_ERROR_GOOGLE
+    results_with_differences[relative_error(GOOGLE_API)] = results_with_differences[
+       relative_error(GOOGLE_API) 
     ].astype(int)
-    results_with_differences[RELATIVE_ERROR_TOMTOM] = results_with_differences[
-        RELATIVE_ERROR_TOMTOM
+    results_with_differences[relative_error(TOMTOM_API)] = results_with_differences[
+       relative_error(TOMTOM_API) 
     ].astype(int)
 
     results_with_differences.to_csv(output_file, index=False)
@@ -93,13 +91,12 @@ def calculate_differences(results: DataFrame, providers: List[str]) -> DataFrame
 def calculate_quantiles(
     results_with_differences: DataFrame,
     quantile: float,
-    absolute_error_str: str,
-    relative_error_str: str,
+    compare_to: str,
 ) -> QuantileErrorResult:
-    quantile_absolute_error = results_with_differences[absolute_error_str].quantile(
+    quantile_absolute_error = results_with_differences[absolute_error(compare_to)].quantile(
         quantile, "higher"
     )
-    quantile_relative_error = results_with_differences[relative_error_str].quantile(
+    quantile_relative_error = results_with_differences[relative_error(compare_to)].quantile(
         quantile, "higher"
     )
     return QuantileErrorResult(

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pandas import DataFrame
 
-from traveltime_google_comparison.collect import Fields,TRAVELTIME_API
+from traveltime_google_comparison.collect import Fields, TRAVELTIME_API
 
 
 def absolute_error(api_provider: str) -> str:

--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -75,8 +75,8 @@ def calculate_differences(results: DataFrame, api_providers: List[str]) -> DataF
     results_with_differences = results.copy()
 
     for provider in api_providers:
-        absolute_error_col = f"absolute_error_{provider}"
-        relative_error_col = f"error_percentage_{provider}"
+        absolute_error_col = absolute_error(provider)
+        relative_error_col = relative_error(provider)
 
         results_with_differences[absolute_error_col] = abs(
             results[Fields.TRAVEL_TIME[provider]]

--- a/src/traveltime_google_comparison/collect.py
+++ b/src/traveltime_google_comparison/collect.py
@@ -13,9 +13,9 @@ from traveltimepy import Coordinates
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import BaseRequestHandler
 
-GOOGLE_API = "google"
-TOMTOM_API = "tomtom"
-TRAVELTIME_API = "traveltime"
+GOOGLE_API = "Google"
+TOMTOM_API = "TomTom"
+TRAVELTIME_API = "TravelTime"
 
 
 @dataclass

--- a/src/traveltime_google_comparison/collect.py
+++ b/src/traveltime_google_comparison/collect.py
@@ -23,7 +23,11 @@ class Fields:
     ORIGIN = "origin"
     DESTINATION = "destination"
     DEPARTURE_TIME = "departure_time"
-    TRAVEL_TIME = {GOOGLE_API: "google_travel_time", TRAVELTIME_API: "tt_travel_time"}
+    TRAVEL_TIME = {
+        GOOGLE_API: "google_travel_time",
+        TOMTOM_API: "tomtom_travel_time",
+        TRAVELTIME_API: "tt_travel_time",
+    }
 
 
 logger = logging.getLogger(__name__)
@@ -112,7 +116,7 @@ async def collect_travel_times(
 
     tasks = generate_tasks(data, time_instants, request_handlers, mode=Mode.DRIVING)
 
-    logger.info(f"Sending {len(tasks)} requests to Google and TravelTime APIs")
+    logger.info(f"Sending {len(tasks)} requests to Google, TomTom and TravelTime APIs")
 
     results = await asyncio.gather(*tasks)
 
@@ -122,6 +126,7 @@ async def collect_travel_times(
     ).agg(
         {
             Fields.TRAVEL_TIME[GOOGLE_API]: "first",
+            Fields.TRAVEL_TIME[TOMTOM_API]: "first",
             Fields.TRAVEL_TIME[TRAVELTIME_API]: "first",
         }
     )

--- a/src/traveltime_google_comparison/collect.py
+++ b/src/traveltime_google_comparison/collect.py
@@ -14,6 +14,7 @@ from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import BaseRequestHandler
 
 GOOGLE_API = "google"
+TOMTOM_API = "tomtom"
 TRAVELTIME_API = "traveltime"
 
 

--- a/src/traveltime_google_comparison/config.py
+++ b/src/traveltime_google_comparison/config.py
@@ -9,6 +9,7 @@ from traveltime_google_comparison.requests.traveltime_credentials import (
 )
 
 DEFAULT_GOOGLE_RPM = 60
+DEFAULT_TOMTOM_RPM = 60
 DEFAULT_TRAVELTIME_RPM = 60
 
 GOOGLE_API_KEY_VAR_NAME = "GOOGLE_API_KEY"
@@ -50,12 +51,20 @@ def parse_args():
         help="Maximum number of requests sent to Google API per minute",
     )
     parser.add_argument(
+        "--tomtom-max-rpm",
+        required=False,
+        type=int,
+        default=DEFAULT_TOMTOM_RPM,
+        help="Maximum number of requests sent to TomTom API per minute",
+    )
+    parser.add_argument(
         "--traveltime-max-rpm",
         required=False,
         type=int,
         default=DEFAULT_TRAVELTIME_RPM,
         help="Maximum number of requests sent to TravelTime API per minute",
     )
+
     parser.add_argument(
         "--skip-data-gathering",
         action=argparse.BooleanOptionalAction,

--- a/src/traveltime_google_comparison/config.py
+++ b/src/traveltime_google_comparison/config.py
@@ -12,6 +12,7 @@ DEFAULT_GOOGLE_RPM = 60
 DEFAULT_TRAVELTIME_RPM = 60
 
 GOOGLE_API_KEY_VAR_NAME = "GOOGLE_API_KEY"
+TOMTOM_API_KEY_VAR_NAME = "TOMTOM_API_KEY"
 TRAVELTIME_APP_ID_VAR_NAME = "TRAVELTIME_APP_ID"
 TRAVELTIME_API_KEY_VAR_NAME = "TRAVELTIME_API_KEY"
 
@@ -72,6 +73,14 @@ def retrieve_google_api_key():
     if not google_api_key:
         raise ValueError(f"{GOOGLE_API_KEY_VAR_NAME} not set in environment variables.")
     return google_api_key
+
+
+def retrieve_tomtom_api_key():
+    tomtom_api_key = os.environ.get(TOMTOM_API_KEY_VAR_NAME)
+
+    if not tomtom_api_key:
+        raise ValueError(f"{TOMTOM_API_KEY_VAR_NAME} not set in environment variables.")
+    return tomtom_api_key 
 
 
 def retrieve_traveltime_credentials() -> TravelTimeCredentials:

--- a/src/traveltime_google_comparison/config.py
+++ b/src/traveltime_google_comparison/config.py
@@ -89,7 +89,7 @@ def retrieve_tomtom_api_key():
 
     if not tomtom_api_key:
         raise ValueError(f"{TOMTOM_API_KEY_VAR_NAME} not set in environment variables.")
-    return tomtom_api_key 
+    return tomtom_api_key
 
 
 def retrieve_traveltime_credentials() -> TravelTimeCredentials:

--- a/src/traveltime_google_comparison/main.py
+++ b/src/traveltime_google_comparison/main.py
@@ -6,7 +6,12 @@ import pandas as pd
 from traveltime_google_comparison import collect
 from traveltime_google_comparison import config
 from traveltime_google_comparison.analysis import run_analysis
-from traveltime_google_comparison.collect import Fields, GOOGLE_API, TRAVELTIME_API, TOMTOM_API
+from traveltime_google_comparison.collect import (
+    Fields,
+    GOOGLE_API,
+    TRAVELTIME_API,
+    TOMTOM_API,
+)
 from traveltime_google_comparison.requests import factory
 
 logging.basicConfig(
@@ -39,6 +44,7 @@ async def run():
                 Fields.DESTINATION,
                 Fields.DEPARTURE_TIME,
                 Fields.TRAVEL_TIME[GOOGLE_API],
+                Fields.TRAVEL_TIME[TOMTOM_API],
                 Fields.TRAVEL_TIME[TRAVELTIME_API],
             ],
         )
@@ -48,6 +54,7 @@ async def run():
         )
     filtered_travel_times_df = travel_times_df.loc[
         travel_times_df[Fields.TRAVEL_TIME[GOOGLE_API]].notna()
+        & travel_times_df[Fields.TRAVEL_TIME[TOMTOM_API]].notna()
         & travel_times_df[Fields.TRAVEL_TIME[TRAVELTIME_API]].notna(),
         :,
     ]

--- a/src/traveltime_google_comparison/main.py
+++ b/src/traveltime_google_comparison/main.py
@@ -51,7 +51,7 @@ async def run():
         )
     else:
         travel_times_df = await collect.collect_travel_times(
-            args, csv, request_handlers
+            args, csv, request_handlers, providers
         )
     filtered_travel_times_df = travel_times_df.loc[
         travel_times_df[Fields.TRAVEL_TIME[GOOGLE_API]].notna()

--- a/src/traveltime_google_comparison/main.py
+++ b/src/traveltime_google_comparison/main.py
@@ -6,7 +6,7 @@ import pandas as pd
 from traveltime_google_comparison import collect
 from traveltime_google_comparison import config
 from traveltime_google_comparison.analysis import run_analysis
-from traveltime_google_comparison.collect import Fields, GOOGLE_API, TRAVELTIME_API
+from traveltime_google_comparison.collect import Fields, GOOGLE_API, TRAVELTIME_API, TOMTOM_API
 from traveltime_google_comparison.requests import factory
 
 logging.basicConfig(

--- a/src/traveltime_google_comparison/main.py
+++ b/src/traveltime_google_comparison/main.py
@@ -29,7 +29,7 @@ async def run():
         return
 
     request_handlers = factory.initialize_request_handlers(
-        args.google_max_rpm, args.traveltime_max_rpm
+        args.google_max_rpm, args.tomtom_max_rpm, args.traveltime_max_rpm
     )
     if args.skip_data_gathering:
         travel_times_df = pd.read_csv(

--- a/src/traveltime_google_comparison/main.py
+++ b/src/traveltime_google_comparison/main.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 async def run():
+    providers = [GOOGLE_API, TOMTOM_API]
     args = config.parse_args()
     csv = pd.read_csv(
         args.input, usecols=[Fields.ORIGIN, Fields.DESTINATION]
@@ -69,7 +70,7 @@ async def run():
             logger.info(
                 f"Skipped {skipped_rows} rows ({100 * skipped_rows / all_rows:.2f}%)"
             )
-        run_analysis(filtered_travel_times_df, args.output, 0.90)
+        run_analysis(filtered_travel_times_df, args.output, 0.90, providers)
 
 
 def main():

--- a/src/traveltime_google_comparison/requests/factory.py
+++ b/src/traveltime_google_comparison/requests/factory.py
@@ -1,24 +1,28 @@
 from typing import Dict
 
-from traveltime_google_comparison.collect import TRAVELTIME_API, GOOGLE_API
+from traveltime_google_comparison.collect import TOMTOM_API, TRAVELTIME_API, GOOGLE_API
 from traveltime_google_comparison.config import (
     retrieve_google_api_key,
+    retrieve_tomtom_api_key,
     retrieve_traveltime_credentials,
 )
 from traveltime_google_comparison.requests.base_handler import BaseRequestHandler
 from traveltime_google_comparison.requests.google_handler import GoogleRequestHandler
+from traveltime_google_comparison.requests.tomtom_handler import TomTomRequestHandler
 from traveltime_google_comparison.requests.traveltime_handler import (
     TravelTimeRequestHandler,
 )
 
 
 def initialize_request_handlers(
-    google_max_rpm, traveltime_max_rpm
+    google_max_rpm, tomtom_max_rpm, traveltime_max_rpm
 ) -> Dict[str, BaseRequestHandler]:
     google_api_key = retrieve_google_api_key()
+    tomtom_api_key = retrieve_tomtom_api_key()
     credentials = retrieve_traveltime_credentials()
     return {
         GOOGLE_API: GoogleRequestHandler(google_api_key, google_max_rpm),
+        TOMTOM_API: TomTomRequestHandler(tomtom_api_key, tomtom_max_rpm),
         TRAVELTIME_API: TravelTimeRequestHandler(
             credentials.app_id, credentials.api_key, traveltime_max_rpm
         ),

--- a/src/traveltime_google_comparison/requests/tomtom_handler.py
+++ b/src/traveltime_google_comparison/requests/tomtom_handler.py
@@ -19,8 +19,6 @@ class TomTomApiError(Exception):
 
 
 class TomTomRequestHandler(BaseRequestHandler):
-    DURATION_IN_TRAFFIC = "duration_in_traffic"
-    DURATION = "duration"
     TOMTOM_ROUTING_URL = "https://api.tomtom.com/routing/1/calculateRoute/"
 
     default_timeout = aiohttp.ClientTimeout(total=60)
@@ -36,10 +34,7 @@ class TomTomRequestHandler(BaseRequestHandler):
         departure_time: datetime,
         mode: Mode,
     ) -> RequestResult:
-        route = "{},{}:{},{}".format(
-            origin.lat, origin.lng, destination.lat, destination.lng
-        )
-
+        route = f"{origin.lat},{origin.lng}:{destination.lat},{destination.lng}"
         params = {
             "key": self.api_key,
             "departAt": departure_time.isoformat(),
@@ -49,7 +44,7 @@ class TomTomRequestHandler(BaseRequestHandler):
             async with aiohttp.ClientSession(
                 timeout=self.default_timeout
             ) as session, session.get(
-                self.TOMTOM_ROUTING_URL + route + "/json", params=params
+                f"{self.TOMTOM_ROUTING_URL}{route}/json", params=params
             ) as response:
                 data = await response.json()
                 if response.status == 200:

--- a/src/traveltime_google_comparison/requests/tomtom_handler.py
+++ b/src/traveltime_google_comparison/requests/tomtom_handler.py
@@ -59,11 +59,11 @@ class TomTomRequestHandler(BaseRequestHandler):
                 else:
                     error_message = data.get("detailedError", "")
                     logger.error(
-                        f"Error in Google API response: {response.status} - {error_message}"
+                        f"Error in TomTom API response: {response.status} - {error_message}"
                     )
                     return RequestResult(None)
         except Exception as e:
-            logger.error(f"Exception during requesting Google API, {e}")
+            logger.error(f"Exception during requesting TomTom API, {e}")
             return RequestResult(None)
 
 

--- a/src/traveltime_google_comparison/requests/tomtom_handler.py
+++ b/src/traveltime_google_comparison/requests/tomtom_handler.py
@@ -1,0 +1,81 @@
+import logging
+from datetime import datetime
+
+import aiohttp
+from aiolimiter import AsyncLimiter
+from traveltimepy import Coordinates
+
+from traveltime_google_comparison.config import Mode
+from traveltime_google_comparison.requests.base_handler import (
+    BaseRequestHandler,
+    RequestResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TomTomApiError(Exception):
+    pass
+
+
+class TomTomRequestHandler(BaseRequestHandler):
+    DURATION_IN_TRAFFIC = "duration_in_traffic"
+    DURATION = "duration"
+    TOMTOM_ROUTING_URL = "https://api.tomtom.com/routing/1/calculateRoute/"
+
+    default_timeout = aiohttp.ClientTimeout(total=60)
+
+    def __init__(self, api_key, max_rpm):
+        self.api_key = api_key
+        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+
+    async def send_request(
+        self,
+        origin: Coordinates,
+        destination: Coordinates,
+        departure_time: datetime,
+        mode: Mode,
+    ) -> RequestResult:
+        route = "{},{}:{},{}".format(
+            origin.lat, origin.lng, destination.lat, destination.lng
+        )
+
+        params = {
+            "key": self.api_key,
+            "departAt": departure_time.isoformat(),
+            "travelMode": get_tomtom_specific_mode(mode),
+        }
+        try:
+            async with aiohttp.ClientSession(
+                timeout=self.default_timeout
+            ) as session, session.get(
+                self.TOMTOM_ROUTING_URL + route + "/json", params=params
+            ) as response:
+                data = await response.json()
+                if response.status == 200:
+                    travel_time = data["routes"][0]["summary"]["travelTimeInSeconds"]
+
+                    if not travel_time:
+                        raise TomTomApiError(
+                            "No route found between origin and destination."
+                        )
+
+                    return RequestResult(travel_time=travel_time)
+                else:
+                    error_message = data.get("detailedError", "")
+                    logger.error(
+                        f"Error in Google API response: {response.status} - {error_message}"
+                    )
+                    return RequestResult(None)
+        except Exception as e:
+            logger.error(f"Exception during requesting Google API, {e}")
+            return RequestResult(None)
+
+
+def get_tomtom_specific_mode(mode: Mode) -> str:
+    if mode == Mode.DRIVING:
+        return "car"
+    elif mode == Mode.PUBLIC_TRANSPORT:
+        return "bus"
+    else:
+        raise ValueError(f"Unsupported mode: `{mode.value}`")

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -43,17 +43,17 @@ odd_df = pd.DataFrame(odd_data)
 def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an_exact_division():
     # Test 1: Basic Quantile Test
 
-    result = calculate_quantiles(odd_df, 0.5, GOOGLE_API)
+    result = calculate_quantiles(odd_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE)
 
     assert isinstance(result, QuantileErrorResult)
     assert result.absolute_error == 30
     assert result.relative_error == 15
 
-    assert calculate_quantiles(odd_df, 0.25, GOOGLE_API) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(odd_df, 0.75, GOOGLE_API) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(odd_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(odd_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(40, 20)
 
-    assert calculate_quantiles(odd_df, 0.0, GOOGLE_API) == QuantileErrorResult(10, 5)
-    assert calculate_quantiles(odd_df, 1.0, GOOGLE_API) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(10, 5)
+    assert calculate_quantiles(odd_df, 1.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
@@ -63,9 +63,9 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
     }
     even_df = pd.DataFrame(even_data)
 
-    assert calculate_quantiles(odd_df, 0.01, GOOGLE_API) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(even_df, 0.5, GOOGLE_API) == QuantileErrorResult(30, 15)
-    assert calculate_quantiles(odd_df, 0.99, GOOGLE_API) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.01, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(even_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(30, 15)
+    assert calculate_quantiles(odd_df, 0.99, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_for_unsorted_list():
@@ -75,8 +75,8 @@ def test_calculate_quantiles_for_unsorted_list():
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(
-        random_order_df, 0.25, ABSOLUTE_ERROR_GOOGLE
+        random_order_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
     ) == QuantileErrorResult(20, 10)
     assert calculate_quantiles(
-        random_order_df, 0.75, ABSOLUTE_ERROR_GOOGLE
+        random_order_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
     ) == QuantileErrorResult(40, 20)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -70,8 +70,8 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
 
 def test_calculate_quantiles_for_unsorted_list():
     random_order_data = {
-        absolute_error: [40, 10, 30, 50, 20],
-        relative_error: [25.0, 20.0, 10.0, 15.0, 5.0],
+        absolute_error_to_google: [40, 10, 30, 50, 20],
+        relative_error_to_google: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -74,5 +74,9 @@ def test_calculate_quantiles_for_unsorted_list():
         relative_error: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
-    assert calculate_quantiles(random_order_df, 0.25, GOOGLE_API) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(random_order_df, 0.75, GOOGLE_API) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(
+        random_order_df, 0.25, GOOGLE_API
+    ) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(
+        random_order_df, 0.75, GOOGLE_API
+    ) == QuantileErrorResult(40, 20)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from traveltime_google_comparison.analysis import (
-    ABSOLUTE_ERROR,
-    RELATIVE_ERROR,
+    absolute_error,
+    relative_error,
     QuantileErrorResult,
     calculate_differences,
     calculate_quantiles,
@@ -15,10 +15,10 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df)
+    result_df = calculate_differences(df, GOOGLE_API)
 
-    assert result_df[ABSOLUTE_ERROR].tolist() == [10, 10, 10]
-    assert result_df[RELATIVE_ERROR].tolist() == [10.0, 5.0, 10.0 / 3]
+    assert result_df[absolute_error].tolist() == [10, 10, 10]
+    assert result_df[relative_error].tolist() == [10.0, 5.0, 10.0 / 3]
 
 
 def test_calculate_differences_survives_division_by_zero():
@@ -27,15 +27,15 @@ def test_calculate_differences_survives_division_by_zero():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df)
+    result_df = calculate_differences(df, GOOGLE_API)
 
-    assert result_df[ABSOLUTE_ERROR].tolist() == [90, 10, 10]
-    assert result_df[RELATIVE_ERROR].tolist() == [float("inf"), 5.0, 10.0 / 3]
+    assert result_df[absolute_error].tolist() == [90, 10, 10]
+    assert result_df[relative_error].tolist() == [float("inf"), 5.0, 10.0 / 3]
 
 
 odd_data = {
-    ABSOLUTE_ERROR: [10, 20, 30, 40, 50],
-    RELATIVE_ERROR: [5.0, 10.0, 15.0, 20.0, 25.0],
+    absolute_error: [10, 20, 30, 40, 50],
+    relative_error: [5.0, 10.0, 15.0, 20.0, 25.0],
 }
 odd_df = pd.DataFrame(odd_data)
 
@@ -58,8 +58,8 @@ def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
     even_data = {
-        ABSOLUTE_ERROR: [10, 20, 30, 40],
-        RELATIVE_ERROR: [5.0, 10.0, 15.0, 20.0],
+        absolute_error: [10, 20, 30, 40],
+        relative_error: [5.0, 10.0, 15.0, 20.0],
     }
     even_df = pd.DataFrame(even_data)
 
@@ -70,8 +70,8 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
 
 def test_calculate_quantiles_for_unsorted_list():
     random_order_data = {
-        ABSOLUTE_ERROR: [40, 10, 30, 50, 20],
-        RELATIVE_ERROR: [25.0, 20.0, 10.0, 15.0, 5.0],
+        absolute_error: [40, 10, 30, 50, 20],
+        relative_error: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(random_order_df, 0.25) == QuantileErrorResult(20, 10)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,13 +1,15 @@
 import pandas as pd
 from traveltime_google_comparison.analysis import (
-    ABSOLUTE_ERROR_GOOGLE,
-    RELATIVE_ERROR_GOOGLE,
     QuantileErrorResult,
+    absolute_error,
     calculate_differences,
     calculate_quantiles,
+    relative_error,
 )
 from traveltime_google_comparison.collect import GOOGLE_API, TRAVELTIME_API, Fields
 
+absolute_error_google = absolute_error(GOOGLE_API)
+relative_error_google = relative_error(GOOGLE_API)
 
 def test_calculate_differences_calculate_absolute_and_relative_differences():
     data = {
@@ -17,8 +19,8 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df, [GOOGLE_API])
 
-    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [10, 10, 10]
-    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [10.0, 5.0, 10.0 / 3]
+    assert result_df[absolute_error_google].tolist() == [10, 10, 10]
+    assert result_df[relative_error_google].tolist() == [10.0, 5.0, 10.0 / 3]
 
 
 def test_calculate_differences_survives_division_by_zero():
@@ -29,13 +31,13 @@ def test_calculate_differences_survives_division_by_zero():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df, [GOOGLE_API])
 
-    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [90, 10, 10]
-    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [float("inf"), 5.0, 10.0 / 3]
+    assert result_df[absolute_error_google].tolist() == [90, 10, 10]
+    assert result_df[relative_error_google].tolist() == [float("inf"), 5.0, 10.0 / 3]
 
 
 odd_data = {
-    ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40, 50],
-    RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0, 25.0],
+    absolute_error_google: [10, 20, 30, 40, 50],
+    relative_error_google: [5.0, 10.0, 15.0, 20.0, 25.0],
 }
 odd_df = pd.DataFrame(odd_data)
 
@@ -44,7 +46,7 @@ def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an
     # Test 1: Basic Quantile Test
 
     result = calculate_quantiles(
-        odd_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.5, GOOGLE_API
     )
 
     assert isinstance(result, QuantileErrorResult)
@@ -52,47 +54,47 @@ def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an
     assert result.relative_error == 15
 
     assert calculate_quantiles(
-        odd_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.25, GOOGLE_API
     ) == QuantileErrorResult(20, 10)
     assert calculate_quantiles(
-        odd_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.75, GOOGLE_API
     ) == QuantileErrorResult(40, 20)
 
     assert calculate_quantiles(
-        odd_df, 0.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.0, GOOGLE_API
     ) == QuantileErrorResult(10, 5)
     assert calculate_quantiles(
-        odd_df, 1.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 1.0, GOOGLE_API
     ) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
     even_data = {
-        ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40],
-        RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0],
+        absolute_error_google: [10, 20, 30, 40],
+        relative_error_google: [5.0, 10.0, 15.0, 20.0],
     }
     even_df = pd.DataFrame(even_data)
 
     assert calculate_quantiles(
-        odd_df, 0.01, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.01, GOOGLE_API
     ) == QuantileErrorResult(20, 10)
     assert calculate_quantiles(
-        even_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        even_df, 0.5, GOOGLE_API
     ) == QuantileErrorResult(30, 15)
     assert calculate_quantiles(
-        odd_df, 0.99, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        odd_df, 0.99, GOOGLE_API
     ) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_for_unsorted_list():
     random_order_data = {
-        ABSOLUTE_ERROR_GOOGLE: [40, 10, 30, 50, 20],
-        RELATIVE_ERROR_GOOGLE: [25.0, 20.0, 10.0, 15.0, 5.0],
+        absolute_error_google: [40, 10, 30, 50, 20],
+        relative_error_google: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(
-        random_order_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        random_order_df, 0.25, GOOGLE_API
     ) == QuantileErrorResult(20, 10)
     assert calculate_quantiles(
-        random_order_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+        random_order_df, 0.75, GOOGLE_API
     ) == QuantileErrorResult(40, 20)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from traveltime_google_comparison.analysis import (
-    absolute_error,
-    relative_error,
+    ABSOLUTE_ERROR_GOOGLE,
+    RELATIVE_ERROR_GOOGLE,
     QuantileErrorResult,
     calculate_differences,
     calculate_quantiles,
@@ -17,8 +17,8 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df)
 
-    assert result_df[absolute_error].tolist() == [10, 10, 10]
-    assert result_df[relative_error].tolist() == [10.0, 5.0, 10.0 / 3]
+    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [10, 10, 10]
+    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [10.0, 5.0, 10.0 / 3]
 
 
 def test_calculate_differences_survives_division_by_zero():
@@ -29,13 +29,13 @@ def test_calculate_differences_survives_division_by_zero():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df)
 
-    assert result_df[absolute_error].tolist() == [90, 10, 10]
-    assert result_df[relative_error].tolist() == [float("inf"), 5.0, 10.0 / 3]
+    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [90, 10, 10]
+    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [float("inf"), 5.0, 10.0 / 3]
 
 
 odd_data = {
-    absolute_error: [10, 20, 30, 40, 50],
-    relative_error: [5.0, 10.0, 15.0, 20.0, 25.0],
+    ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40, 50],
+    RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0, 25.0],
 }
 odd_df = pd.DataFrame(odd_data)
 
@@ -58,8 +58,8 @@ def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
     even_data = {
-        absolute_error: [10, 20, 30, 40],
-        relative_error: [5.0, 10.0, 15.0, 20.0],
+        ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40],
+        RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0],
     }
     even_df = pd.DataFrame(even_data)
 
@@ -70,8 +70,8 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
 
 def test_calculate_quantiles_for_unsorted_list():
     random_order_data = {
-        absolute_error_to_google: [40, 10, 30, 50, 20],
-        relative_error_to_google: [25.0, 20.0, 10.0, 15.0, 5.0],
+        ABSOLUTE_ERROR_GOOGLE: [40, 10, 30, 50, 20],
+        RELATIVE_ERROR_GOOGLE: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -15,7 +15,7 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df)
+    result_df = calculate_differences(df, [GOOGLE_API])
 
     assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [10, 10, 10]
     assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [10.0, 5.0, 10.0 / 3]
@@ -27,7 +27,7 @@ def test_calculate_differences_survives_division_by_zero():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df)
+    result_df = calculate_differences(df, [GOOGLE_API])
 
     assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [90, 10, 10]
     assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [float("inf"), 5.0, 10.0 / 3]

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -8,9 +8,8 @@ from traveltime_google_comparison.analysis import (
 )
 from traveltime_google_comparison.collect import GOOGLE_API, TRAVELTIME_API, Fields
 
-absolute_error_google = absolute_error(GOOGLE_API)
-relative_error_google = relative_error(GOOGLE_API)
-
+ABSOLUTE_ERROR_GOOGLE = absolute_error(GOOGLE_API)
+RELATIVE_ERROR_GOOGLE = relative_error(GOOGLE_API)
 
 def test_calculate_differences_calculate_absolute_and_relative_differences():
     data = {
@@ -20,8 +19,8 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df, [GOOGLE_API])
 
-    assert result_df[absolute_error_google].tolist() == [10, 10, 10]
-    assert result_df[relative_error_google].tolist() == [10.0, 5.0, 10.0 / 3]
+    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [10, 10, 10]
+    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [10.0, 5.0, 10.0 / 3]
 
 
 def test_calculate_differences_survives_division_by_zero():
@@ -32,13 +31,13 @@ def test_calculate_differences_survives_division_by_zero():
     df = pd.DataFrame(data)
     result_df = calculate_differences(df, [GOOGLE_API])
 
-    assert result_df[absolute_error_google].tolist() == [90, 10, 10]
-    assert result_df[relative_error_google].tolist() == [float("inf"), 5.0, 10.0 / 3]
+    assert result_df[ABSOLUTE_ERROR_GOOGLE].tolist() == [90, 10, 10]
+    assert result_df[RELATIVE_ERROR_GOOGLE].tolist() == [float("inf"), 5.0, 10.0 / 3]
 
 
 odd_data = {
-    absolute_error_google: [10, 20, 30, 40, 50],
-    relative_error_google: [5.0, 10.0, 15.0, 20.0, 25.0],
+    ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40, 50],
+    RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0, 25.0],
 }
 odd_df = pd.DataFrame(odd_data)
 
@@ -61,8 +60,8 @@ def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
     even_data = {
-        absolute_error_google: [10, 20, 30, 40],
-        relative_error_google: [5.0, 10.0, 15.0, 20.0],
+        ABSOLUTE_ERROR_GOOGLE: [10, 20, 30, 40],
+        RELATIVE_ERROR_GOOGLE: [5.0, 10.0, 15.0, 20.0],
     }
     even_df = pd.DataFrame(even_data)
 
@@ -73,8 +72,8 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
 
 def test_calculate_quantiles_for_unsorted_list():
     random_order_data = {
-        absolute_error_google: [40, 10, 30, 50, 20],
-        relative_error_google: [25.0, 20.0, 10.0, 15.0, 5.0],
+        ABSOLUTE_ERROR_GOOGLE: [40, 10, 30, 50, 20],
+        RELATIVE_ERROR_GOOGLE: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -11,6 +11,7 @@ from traveltime_google_comparison.collect import GOOGLE_API, TRAVELTIME_API, Fie
 absolute_error_google = absolute_error(GOOGLE_API)
 relative_error_google = relative_error(GOOGLE_API)
 
+
 def test_calculate_differences_calculate_absolute_and_relative_differences():
     data = {
         Fields.TRAVEL_TIME[GOOGLE_API]: [100, 200, 300],
@@ -45,27 +46,17 @@ odd_df = pd.DataFrame(odd_data)
 def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an_exact_division():
     # Test 1: Basic Quantile Test
 
-    result = calculate_quantiles(
-        odd_df, 0.5, GOOGLE_API
-    )
+    result = calculate_quantiles(odd_df, 0.5, GOOGLE_API)
 
     assert isinstance(result, QuantileErrorResult)
     assert result.absolute_error == 30
     assert result.relative_error == 15
 
-    assert calculate_quantiles(
-        odd_df, 0.25, GOOGLE_API
-    ) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(
-        odd_df, 0.75, GOOGLE_API
-    ) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(odd_df, 0.25, GOOGLE_API) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(odd_df, 0.75, GOOGLE_API) == QuantileErrorResult(40, 20)
 
-    assert calculate_quantiles(
-        odd_df, 0.0, GOOGLE_API
-    ) == QuantileErrorResult(10, 5)
-    assert calculate_quantiles(
-        odd_df, 1.0, GOOGLE_API
-    ) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.0, GOOGLE_API) == QuantileErrorResult(10, 5)
+    assert calculate_quantiles(odd_df, 1.0, GOOGLE_API) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
@@ -75,15 +66,9 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
     }
     even_df = pd.DataFrame(even_data)
 
-    assert calculate_quantiles(
-        odd_df, 0.01, GOOGLE_API
-    ) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(
-        even_df, 0.5, GOOGLE_API
-    ) == QuantileErrorResult(30, 15)
-    assert calculate_quantiles(
-        odd_df, 0.99, GOOGLE_API
-    ) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.01, GOOGLE_API) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(even_df, 0.5, GOOGLE_API) == QuantileErrorResult(30, 15)
+    assert calculate_quantiles(odd_df, 0.99, GOOGLE_API) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_for_unsorted_list():

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -43,17 +43,27 @@ odd_df = pd.DataFrame(odd_data)
 def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an_exact_division():
     # Test 1: Basic Quantile Test
 
-    result = calculate_quantiles(odd_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE)
+    result = calculate_quantiles(
+        odd_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    )
 
     assert isinstance(result, QuantileErrorResult)
     assert result.absolute_error == 30
     assert result.relative_error == 15
 
-    assert calculate_quantiles(odd_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(odd_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(
+        odd_df, 0.25, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(
+        odd_df, 0.75, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(40, 20)
 
-    assert calculate_quantiles(odd_df, 0.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(10, 5)
-    assert calculate_quantiles(odd_df, 1.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(
+        odd_df, 0.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(10, 5)
+    assert calculate_quantiles(
+        odd_df, 1.0, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
@@ -63,9 +73,15 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
     }
     even_df = pd.DataFrame(even_data)
 
-    assert calculate_quantiles(odd_df, 0.01, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(even_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(30, 15)
-    assert calculate_quantiles(odd_df, 0.99, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(
+        odd_df, 0.01, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(
+        even_df, 0.5, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(30, 15)
+    assert calculate_quantiles(
+        odd_df, 0.99, ABSOLUTE_ERROR_GOOGLE, RELATIVE_ERROR_GOOGLE
+    ) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_for_unsorted_list():

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -15,7 +15,7 @@ def test_calculate_differences_calculate_absolute_and_relative_differences():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df, GOOGLE_API)
+    result_df = calculate_differences(df)
 
     assert result_df[absolute_error].tolist() == [10, 10, 10]
     assert result_df[relative_error].tolist() == [10.0, 5.0, 10.0 / 3]
@@ -27,7 +27,7 @@ def test_calculate_differences_survives_division_by_zero():
         Fields.TRAVEL_TIME[TRAVELTIME_API]: [90, 210, 290],
     }
     df = pd.DataFrame(data)
-    result_df = calculate_differences(df, GOOGLE_API)
+    result_df = calculate_differences(df)
 
     assert result_df[absolute_error].tolist() == [90, 10, 10]
     assert result_df[relative_error].tolist() == [float("inf"), 5.0, 10.0 / 3]
@@ -43,17 +43,17 @@ odd_df = pd.DataFrame(odd_data)
 def test_calculate_quantiles_return_exact_element_for_quantile_which_provides_an_exact_division():
     # Test 1: Basic Quantile Test
 
-    result = calculate_quantiles(odd_df, 0.5)
+    result = calculate_quantiles(odd_df, 0.5, GOOGLE_API)
 
     assert isinstance(result, QuantileErrorResult)
     assert result.absolute_error == 30
     assert result.relative_error == 15
 
-    assert calculate_quantiles(odd_df, 0.25) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(odd_df, 0.75) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(odd_df, 0.25, GOOGLE_API) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(odd_df, 0.75, GOOGLE_API) == QuantileErrorResult(40, 20)
 
-    assert calculate_quantiles(odd_df, 0.0) == QuantileErrorResult(10, 5)
-    assert calculate_quantiles(odd_df, 1.0) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.0, GOOGLE_API) == QuantileErrorResult(10, 5)
+    assert calculate_quantiles(odd_df, 1.0, GOOGLE_API) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_provide_an_exact_division():
@@ -63,9 +63,9 @@ def test_calculate_quantiles_return_next_element_for_quantile_which_does_not_pro
     }
     even_df = pd.DataFrame(even_data)
 
-    assert calculate_quantiles(odd_df, 0.01) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(even_df, 0.5) == QuantileErrorResult(30, 15)
-    assert calculate_quantiles(odd_df, 0.99) == QuantileErrorResult(50, 25)
+    assert calculate_quantiles(odd_df, 0.01, GOOGLE_API) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(even_df, 0.5, GOOGLE_API) == QuantileErrorResult(30, 15)
+    assert calculate_quantiles(odd_df, 0.99, GOOGLE_API) == QuantileErrorResult(50, 25)
 
 
 def test_calculate_quantiles_for_unsorted_list():
@@ -74,5 +74,5 @@ def test_calculate_quantiles_for_unsorted_list():
         relative_error: [25.0, 20.0, 10.0, 15.0, 5.0],
     }
     random_order_df = pd.DataFrame(random_order_data)
-    assert calculate_quantiles(random_order_df, 0.25) == QuantileErrorResult(20, 10)
-    assert calculate_quantiles(random_order_df, 0.75) == QuantileErrorResult(40, 20)
+    assert calculate_quantiles(random_order_df, 0.25, GOOGLE_API) == QuantileErrorResult(20, 10)
+    assert calculate_quantiles(random_order_df, 0.75, GOOGLE_API) == QuantileErrorResult(40, 20)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -75,8 +75,8 @@ def test_calculate_quantiles_for_unsorted_list():
     }
     random_order_df = pd.DataFrame(random_order_data)
     assert calculate_quantiles(
-        random_order_df, 0.25, GOOGLE_API
+        random_order_df, 0.25, ABSOLUTE_ERROR_GOOGLE
     ) == QuantileErrorResult(20, 10)
     assert calculate_quantiles(
-        random_order_df, 0.75, GOOGLE_API
+        random_order_df, 0.75, ABSOLUTE_ERROR_GOOGLE
     ) == QuantileErrorResult(40, 20)

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -11,6 +11,7 @@ from traveltime_google_comparison.collect import GOOGLE_API, TRAVELTIME_API, Fie
 ABSOLUTE_ERROR_GOOGLE = absolute_error(GOOGLE_API)
 RELATIVE_ERROR_GOOGLE = relative_error(GOOGLE_API)
 
+
 def test_calculate_differences_calculate_absolute_and_relative_differences():
     data = {
         Fields.TRAVEL_TIME[GOOGLE_API]: [100, 200, 300],


### PR DESCRIPTION
Adding TomTom to the comparison tool.

Now the output will look something like this:
```
origin,destination,departure_time,google_travel_time,tomtom_travel_time,tt_travel_time,error_percentage_google,error_percentage_tomtom
"52.200400622501455, 0.1082577055247136","52.21614536733819, 0.15782831362961777",2024-09-20 07:00:00+0100,606.0,775.0,956.0,57,23
```
Here are the different types of travel times TomTom can calculate. By default, it includes traffic delays, as we do, so I don't think we need to modify it in any way.
![image](https://github.com/user-attachments/assets/312dab5c-3b9e-4478-a0eb-0d3bfffc7ae8)