### PR TITLE
Fixing type cast failure from NaN

### DIFF
--- a/src/traveltime_google_comparison/analysis.py
+++ b/src/traveltime_google_comparison/analysis.py
@@ -46,7 +46,7 @@ def log_results(
 def format_results_for_csv(
     results_with_differences: DataFrame, api_providers: List[str]
 ) -> DataFrame:
-    formatted_results = results_with_differences.copy()
+    formatted_results = results_with_differences.copy().dropna()
 
     for provider in api_providers:
         formatted_results = formatted_results.drop(columns=[absolute_error(provider)])


### PR DESCRIPTION
This method ends with `asType(int)`, which fails either due to inf or NaN values in the data (most likely NaN in our case, tho I couldn't confirm here, it happened once after 3000~ requests, didn't have debug logs enabled).

Test running with these changes.