### PR TITLE
Fixing rate limiter

### DIFF
--- a/src/traveltime_google_comparison/requests/base_handler.py
+++ b/src/traveltime_google_comparison/requests/base_handler.py
@@ -32,3 +32,20 @@ class BaseRequestHandler(ABC):
     @property
     def rate_limiter(self) -> AsyncLimiter:
         return self._rate_limiter
+
+
+def create_async_limiter(max_rpm: int) -> AsyncLimiter:
+    # Convert max_rpm to requests per second
+    rps = max_rpm / 60
+
+    if rps < 1:
+        # For rates less than 1 per second, we'll use a longer time period
+        # to allow fractional rates, but keep max_rate low to prevent bursts
+        time_period = min(60, 1 / rps)
+        max_rate = rps * time_period
+    else:
+        # For rates of 1 per second or higher, use a 1-second time period
+        time_period = 1
+        max_rate = rps
+
+    return AsyncLimiter(max_rate=max_rate, time_period=time_period)

--- a/src/traveltime_google_comparison/requests/google_handler.py
+++ b/src/traveltime_google_comparison/requests/google_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class GoogleRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/here_handler.py
+++ b/src/traveltime_google_comparison/requests/here_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class HereRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/mapbox_handler.py
+++ b/src/traveltime_google_comparison/requests/mapbox_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class MapboxRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/openroutes_handler.py
+++ b/src/traveltime_google_comparison/requests/openroutes_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class OpenRoutesRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm, 60)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/osrm_handler.py
+++ b/src/traveltime_google_comparison/requests/osrm_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class OSRMRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/tomtom_handler.py
+++ b/src/traveltime_google_comparison/requests/tomtom_handler.py
@@ -2,13 +2,13 @@ import logging
 from datetime import datetime
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from traveltimepy import Coordinates
 
 from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class TomTomRequestHandler(BaseRequestHandler):
 
     def __init__(self, api_key, max_rpm):
         self.api_key = api_key
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
 
     async def send_request(
         self,

--- a/src/traveltime_google_comparison/requests/traveltime_handler.py
+++ b/src/traveltime_google_comparison/requests/traveltime_handler.py
@@ -31,7 +31,6 @@ class TravelTimeRequestHandler(BaseRequestHandler):
             app_id=app_id, api_key=api_key, user_agent="Travel Time Comparison Tool"
         )
         self._rate_limiter = create_async_limiter(max_rpm)
-        print(self._rate_limiter.max_rate)
 
     async def send_request(
         self,
@@ -45,7 +44,6 @@ class TravelTimeRequestHandler(BaseRequestHandler):
             Location(id=self.DESTINATION_ID, coords=destination),
         ]
         results = None
-        """
         try:
             results = await self.sdk.routes_async(
                 locations=locations,
@@ -72,8 +70,7 @@ class TravelTimeRequestHandler(BaseRequestHandler):
             return RequestResult(None)
 
         properties = results[0].locations[0].properties[0]
-        """
-        return RequestResult(travel_time=30)
+        return RequestResult(travel_time=properties.travel_time)
 
 
 class RouteNotFoundError(Exception):

--- a/src/traveltime_google_comparison/requests/traveltime_handler.py
+++ b/src/traveltime_google_comparison/requests/traveltime_handler.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Union
 import logging
 
-from aiolimiter import AsyncLimiter
 from traveltimepy import (
     Location,
     Coordinates,
@@ -17,6 +16,7 @@ from traveltime_google_comparison.config import Mode
 from traveltime_google_comparison.requests.base_handler import (
     BaseRequestHandler,
     RequestResult,
+    create_async_limiter,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,8 @@ class TravelTimeRequestHandler(BaseRequestHandler):
         self.sdk = TravelTimeSdk(
             app_id=app_id, api_key=api_key, user_agent="Travel Time Comparison Tool"
         )
-        self._rate_limiter = AsyncLimiter(max_rpm // 60, 1)
+        self._rate_limiter = create_async_limiter(max_rpm)
+        print(self._rate_limiter.max_rate)
 
     async def send_request(
         self,
@@ -44,6 +45,7 @@ class TravelTimeRequestHandler(BaseRequestHandler):
             Location(id=self.DESTINATION_ID, coords=destination),
         ]
         results = None
+        """
         try:
             results = await self.sdk.routes_async(
                 locations=locations,
@@ -70,7 +72,8 @@ class TravelTimeRequestHandler(BaseRequestHandler):
             return RequestResult(None)
 
         properties = results[0].locations[0].properties[0]
-        return RequestResult(travel_time=properties.travel_time)
+        """
+        return RequestResult(travel_time=30)
 
 
 class RouteNotFoundError(Exception):


### PR DESCRIPTION
My fix here https://github.com/traveltime-dev/traveltime-google-comparison/pull/13 for RPMs less than 60 is not ideal, as it allows quick bursts of requests, instead of them being evenly spread out over the minute.

If we're sending a request each second, then the `max_rate` can't be less than 1, or the lib will complain, so 1RPS or 60 RPM is the lowest we can have, which is not good.

This fixes the issue by always having at least 1RPS, but increasing the time gap between requests, if RPM is less than 60.